### PR TITLE
restructured eat-out modal into standard dropdown selector

### DIFF
--- a/eatout.html
+++ b/eatout.html
@@ -22,20 +22,9 @@
     </div>
   </header>
 
-    <!-- Button trigger modal -->
-<button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#filterModal">
-  Filters
-</button>
 
-<!-- Modal -->
-<div class="modal fade" id="filterModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h1 class="modal-title fs-5 text-dark" id="exampleModalLabel">Let's get specific!</h1>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body">
+      <h1 class="fs-5 text-dark" >Let's get specific!</h1>
+      
         <div class="mb-3">
           <form action="">
             <label for="cuisine" class="text-dark">Filter by cuisine:</label>
@@ -75,12 +64,7 @@
             <br><br>
           </form>
         </div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-primary search" data-bs-dismiss="modal">Search</button>
-      </div>
-    </div>
-  </div>
+        <button type="button" class="btn btn-primary search mb-3">Search</button>
 
   <!-- RESTAURANTS -->
   <section id="restaurant-cards" class="row">


### PR DESCRIPTION
## Purpose

Eat out modal was unnecessary, restructuring it would allow the search and filter functions to be visible from the start on this page.

## Changes

Removed modal buttons, divs and class tags.

## Steps to Reproduce or Test

Open eatout.html and observe new dropdown menus.