### PR TITLE
Resize the map on desktop view

### DIFF
--- a/assets/css/eatout-styles.css
+++ b/assets/css/eatout-styles.css
@@ -194,6 +194,16 @@ main {
     }
 
     .map-card {
-        min-width: 300px;
+        min-width: 400px;
+        min-height: 600px;
+        margin-left: 0%;
+    }
+
+    .map {
+        min-height: 600px; 
+    }
+
+    .rest-cards {
+        margin: 1%;
     }
 }


### PR DESCRIPTION
## Purpose

Resize the map on desktop view.

Fixes #[127]

## Changes

Changed the left margin to 0% and the cards margin to 1% all around.

## Steps to Reproduce or Test

N/A

## Optional GIF

N/A
