### PR TITLE
144 add zipcode modal for indexhtml night out button

### DIFF
--- a/assets/css/stylesheet.css
+++ b/assets/css/stylesheet.css
@@ -83,6 +83,16 @@ h2 {
     border-radius: 0px;
 }
 
+#zipcode-modal-content2, #zipcode-submit-button2 {
+    border: 2px solid black;
+    border-radius: 0px;
+}
+
+#zipcode-submit-button2:hover {
+    border: 2px solid #b1b1b1;
+    border-radius: 0px;
+}
+
 .modal-padding {
     margin: 0px !important;
 }

--- a/assets/js/homepage.js
+++ b/assets/js/homepage.js
@@ -2,8 +2,11 @@
 const nightOutButton = document.querySelector("#nightOut-button");
 const eatOutButton = document.querySelector("#eatOut-button");
 const zipInput = document.querySelector('#zip-input');
+const zipInput2 = document.querySelector('#zip-input2');
 const submitButton = document.querySelector('#zipcode-submit-button');
+const submitButton2 = document.querySelector('#zipcode-submit-button2');
 const warning = document.querySelector('#warning');
+const warning2 = document.querySelector('#warning2');
 
 // EVENT LISTENERS
 eatOutButton.addEventListener('click', function (event) {
@@ -13,7 +16,7 @@ eatOutButton.addEventListener('click', function (event) {
 
 nightOutButton.addEventListener('click', function (event) {
     event.preventDefault();
-    window.location.href = "nightout.html";
+    // window.location.href = "nightout.html";
 });
 
 submitButton.addEventListener('click', function (event) {
@@ -28,5 +31,20 @@ submitButton.addEventListener('click', function (event) {
     else {
         localStorage.setItem('zipCode', zipCode);
         window.location.href = "eatout.html";
+    }
+});
+
+submitButton2.addEventListener('click', function (event) {
+    event.preventDefault();
+
+    let zipCode2 = zipInput2.value;
+
+    if (zipCode2 === '') {
+        //displayMessage('error', 'Please enter a ZIP Code.');
+        warning2.textContent = "Please enter a Zipcode"
+    }
+    else {
+        localStorage.setItem('zipCode', zipCode2);
+        window.location.href = "nightout.html";
     }
 });

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
   
     <!-- BUTTONS -->
     <button type="button" data-bs-toggle="modal" id="eatOut-button" data-bs-target="#zipCodeModal">EAT OUT →</button>
-    <button type="button" id="nightOut-button">NIGHT OUT →</button>
+    <button type="button" data-bs-toggle="modal" id="nightOut-button" data-bs-target="#zipCodeModal2">NIGHT OUT →</button>
 
     <!-- Modal -->
     <div class="modal fade" id="zipCodeModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
@@ -51,6 +51,29 @@
           </div>
           <div class="modal-footer">
             <button type="button" class="btn" id="zipcode-submit-button">I'm Hungry!</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Modal -->
+    <div class="modal fade" id="zipCodeModal2" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content" id="zipcode-modal-content">
+          <div class="modal-header">
+            <h3 class="modal-title fs-5 text-dark" id="exampleModalLabel">What's your ZIP code?</h3>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <div class="mb-3 modal-padding">
+              <form action="">
+                <input type="text" class="form-control" id="zip-input2" placeholder="Zipcode" required>
+                <span class="text-danger" id="warning2"></span>
+              </form>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn" id="zipcode-submit-button2">Let's Go!</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Purpose

Night Out button required a zipcode input in the same way the Eat Out button did.

Fixes #{144]

## Changes

Added and configured zipcode modal for night out button to save zipcode input in localStorage and redirect to the nightout.html page. Edited the stylesheet.css to reflect the style changes of the Eat Out modal.

## Steps to Reproduce or Test

Click on the night-out button to test functionality